### PR TITLE
Add PKGBUILD for the Arch AUR

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,17 @@
+# Maintainer: Refined7075 <yxgw5rdy2@mozmail.com>
+pkgname=dorion-bin
+pkgver=0.5.0
+pkgrel=1
+pkgdesc="An alternative Discord client aimed and lower-spec or storage-sensitive PCs that supports themes, plugins, and more!"
+arch=('x86_64')
+url="https://spikehd.github.io/projects/dorion/"
+license=('GPL3')
+depends=('libayatana-appindicator' 'webkit2gtk' 'gtk3')
+provides=('dorion')
+conflicts=('dorion')
+source=("https://github.com/SpikeHD/Dorion/releases/download/v${pkgver}/dorion_${pkgver}_amd64.deb")
+sha256sums=('e29cb66b447ba6a733e5aded5bb768ab4678f3eeb32c254da79117699ba05967')
+
+package() {
+    bsdtar -xf "$srcdir/data.tar.gz" -C "$pkgdir"
+}


### PR DESCRIPTION
Hello, I am Refined7075 on the AUR. I noticed #30 and thought I would add the PKGBUILD that I used... someone may be able to adapt it and use it to make a dorion-git release (I have no idea how and have only just started publishing to the AUR), but overall it just downloads the dpkg (v5.0.0 and it has to be updated manually), checks it's sha256sum, and puts the files in the correct directory (I copied most of it from another package with similar dpkg releases and no raw binaries). 