### PR TITLE
fix(all): user popout

### DIFF
--- a/src/extra.css
+++ b/src/extra.css
@@ -7,11 +7,6 @@ ul[class^='tree']
   display: none !important;
 }
 
-div[class^='layerContainer-'] {
-  overflow: clip;
-  top: 30px;
-}
-
-div[class^='layerContainer-'] div[class^='userProfileOuter-'] {
+div[class*='userProfileOuter'] {
   --custom-user-popout-outside-components-height: 30px;
 }


### PR DESCRIPTION
After Discord update, #118 is happening again. The `div` class is not begin with `userProfileOuter` but `userPopoutOuter` instead.

Changes also mimicking the original CSS of discord which looks like:
```CSS
.userProfileOuter__46bb7 {
    ...
    --custom-user-popout-outside-components-height: 1px;
}
```