### PR TITLE
WIP: Maximize button toggles maximized state

### DIFF
--- a/src-tauri/injection/injection.js
+++ b/src-tauri/injection/injection.js
@@ -61,8 +61,8 @@ function minimize() {
   window.__TAURI__.invoke('minimize')
 }
 
-function maximize() {
-  window.__TAURI__.invoke('maximize')
+function toggleMaximize() {
+  window.__TAURI__.invoke('toggle_maximize')
 }
 
 async function createTopBar() {
@@ -119,7 +119,7 @@ function onClientLoad() {
 function initTopBarEvents() {
   document.querySelector('#topclose').onclick = close
   document.querySelector('#topmin').onclick = minimize
-  document.querySelector('#topmax').onclick = maximize
+  document.querySelector('#topmax').onclick = toggleMaximize
 }
 
 function applyNotificationCount() {

--- a/src-tauri/src/functionality/window.rs
+++ b/src-tauri/src/functionality/window.rs
@@ -13,10 +13,14 @@ pub fn minimize(win: Window) {
   win.minimize().unwrap_or_default();
 }
 
-// Maximize
+// Toggle maximize
 #[tauri::command]
-pub fn maximize(win: Window) {
-  win.maximize().unwrap_or_default();
+pub fn toggle_maximize(win: Window) {
+  if win.is_maximized().unwrap_or_default() {
+    win.unmaximize().unwrap_or_default();
+  } else {
+    win.maximize().unwrap_or_default();
+  }
 }
 
 // Close

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -130,7 +130,7 @@ fn main() {
       should_disable_plugins,
       functionality::streamer_mode::start_streamer_mode_watcher,
       functionality::window::minimize,
-      functionality::window::maximize,
+      functionality::window::toggle_maximize,
       functionality::window::close,
       css_preprocess::clear_css_cache,
       css_preprocess::localize_imports,


### PR DESCRIPTION
Maximize button now toggles maximized state. In windowed mode the functionality is unchanged. However, when clicking the maximize button in maximized state, it now unmaximizes the window instead of doing nothing.