### PR TITLE
Fix theme applying over client mod theme

### DIFF
--- a/src-tauri/injection/preinject.ts
+++ b/src-tauri/injection/preinject.ts
@@ -111,8 +111,8 @@ async function init() {
     })
   })
 
-  let themeJs = await handleThemeInjection()
-  themeJs += await handleClientModThemeInjection()
+  let themeJs = await handleClientModThemeInjection()
+  themeJs += await handleThemeInjection()
 
   updateOverlay({
     midtitle: 'Getting injection JS...'


### PR DESCRIPTION
This PR changes the order of themes being applied, so user themes can override and change client mod components