### PR TITLE
Add MacOS Homebrew tap to package repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ I do **not** maintain any instances of Dorion in any package repositories myself
     ```sh
     nix-shell -p dorion
     ```
+* MacOS:
+  * Homebrew (Maintained by [psharma04](https://github.com/psharma04))
+    ```sh
+    brew tap psharma04/dorion
+    brew install --cask dorion
+    ```
 
 > [!NOTE]
 > Maintaining Dorion in a different package repository that I don't know about? Feel free to [open a PR](https://github.com/SpikeHD/Dorion/pulls) to add it here!


### PR DESCRIPTION
I have created a Homebrew tap so that Dorion can be installed via command line on both Intel and Arm MacOS devices. 

I am currently working on configuring the repository to automatically grab new Dorion releases, hence marking this as a draft.

Would be happy to hand this over to the main project maintainers once everything is running smoothly.