### PR TITLE
feat: proper light mode and fix icons cut off titlebar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,15 @@
     text-align: center;
     height: 100%;
     width: 100%;
+    background: #2f3136;
+  }
+
+  #title,
+  #midtitle,
+  #subtitle,
+  #safemode,
+  #logContainer {
+    color: #f2f3f5;
   }
 
   #title {

--- a/src/index.html
+++ b/src/index.html
@@ -32,30 +32,24 @@
 
   #container {
     position: relative;
-
-    background: #2f3136;
     user-select: none;
-
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     text-align: center;
-
     height: 100%;
     width: 100%;
   }
 
   #title {
     font-size: 5rem;
-    color: #fff;
     font-family: 'Courier New', monospace;
     font-weight: bold;
   }
 
   #midtitle {
     font-size: 2rem;
-    color: #fff;
     font-family: Arial, Helvetica, sans-serif;
     font-weight: normal;
     margin: 20px;
@@ -64,7 +58,6 @@
 
   #subtitle {
     font-size: 1rem;
-    color: #fff;
     font-family: Arial, Helvetica, sans-serif;
     font-weight: normal;
     margin: 20px;
@@ -72,29 +65,49 @@
 
   #safemode {
     opacity: 0;
-
     margin: 20px;
-    color: #fff;
     font-family: Arial, Helvetica, sans-serif;
     font-weight: normal;
-
     transition: all 1s ease;
   }
 
   #logContainer {
     font-size: 1rem;
     width: 70%;
-
     height: 20px;
-
     overflow: none;
-
     text-align: center;
-
-    color: #fff;
   }
 
   .show {
     opacity: 1 !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    #container {
+      background: #2f3136;
+    }
+
+    #title,
+    #midtitle,
+    #subtitle,
+    #safemode,
+    #logContainer {
+      color: #f2f3f5;
+    }
+  }
+
+  @media (prefers-color-scheme: light) {
+    #container {
+      background: #f2f3f5;
+    }
+
+    #title,
+    #midtitle,
+    #subtitle,
+    #safemode,
+    #logContainer {
+      color: #2f3136;
+    }
   }
 </style>

--- a/src/top.html
+++ b/src/top.html
@@ -39,7 +39,7 @@
               stroke-linecap: butt;
               stroke-linejoin: miter;
               stroke-miterlimit: 10;
-              fill: rgb(255, 255, 255);
+              fill: currentColor;
               fill-rule: nonzero;
               opacity: 1;
             "
@@ -55,7 +55,7 @@
               stroke-linecap: butt;
               stroke-linejoin: miter;
               stroke-miterlimit: 10;
-              fill: rgb(255, 255, 255);
+              fill: currentColor;
               fill-rule: nonzero;
               opacity: 1;
             "
@@ -101,7 +101,7 @@
               stroke-linecap: butt;
               stroke-linejoin: miter;
               stroke-miterlimit: 10;
-              fill: rgb(255, 255, 255);
+              fill: currentColor;
               fill-rule: nonzero;
               opacity: 1;
             "
@@ -144,7 +144,7 @@
               stroke-linecap: butt;
               stroke-linejoin: miter;
               stroke-miterlimit: 10;
-              fill: rgb(255, 255, 255);
+              fill: currentColor;
               fill-rule: nonzero;
               opacity: 1;
             "
@@ -189,7 +189,7 @@
               stroke-linecap: butt;
               stroke-linejoin: miter;
               stroke-miterlimit: 10;
-              fill: rgb(255, 255, 255);
+              fill: currentColor;
               fill-rule: nonzero;
               opacity: 1;
             "
@@ -205,7 +205,7 @@
               stroke-linecap: butt;
               stroke-linejoin: miter;
               stroke-miterlimit: 10;
-              fill: rgb(255, 255, 255);
+              fill: currentColor;
               fill-rule: nonzero;
               opacity: 1;
             "
@@ -271,10 +271,8 @@
     align-items: center;
     justify-content: center;
 
-    height: 100%;
-    width: 32px;
-
-    padding: 0 6px;
+    height: 24px;
+    width: 44px;
 
     transition: all 0.1s ease-in-out;
   }
@@ -291,6 +289,13 @@
     display: none;
   }
 
+  #topclose svg,
+  #topmin svg,
+  #topmax svg {
+    height: 10px !important;
+    width: 10px !important;
+  }
+
   #topmax:not(.maximized) #svgmax,
   #topmax.maximized #svgunmax {
     display: initial;
@@ -298,10 +303,11 @@
 
   #topclose:hover {
     background: var(--status-danger);
+    color: var(--white);
   }
 
-  #topright svg {
+  /* #topright svg {
     height: 45%;
     width: 60%;
-  }
+  } */
 </style>

--- a/src/top.html
+++ b/src/top.html
@@ -305,9 +305,4 @@
     background: var(--status-danger);
     color: var(--white);
   }
-
-  /* #topright svg {
-    height: 45%;
-    width: 60%;
-  } */
 </style>


### PR DESCRIPTION
This PR takes care of 2 things

## Add proper light mode support

### Old colors in light mode

![img-2024-12-03-14-06-06](https://github.com/user-attachments/assets/547a71fc-37d0-4cf6-9ca5-2b641e424a28)

### New colors in light mode

![img-2024-12-03-14-25-09](https://github.com/user-attachments/assets/535443e6-0087-4e98-832d-deea29974647)

### New splash screen in light mode

![img-2024-12-03-14-25-20](https://github.com/user-attachments/assets/1adb2d04-9091-451b-9cd8-254f00029719)

## Fix the window button icons from being cut off a little

### Old icons, with cut-off

![img-2024-12-03-15-56-17](https://github.com/user-attachments/assets/5aefc51e-8083-46d5-9251-605bb9988915)

### New icons, without cut-off

![img-2024-12-03-15-58-52](https://github.com/user-attachments/assets/e79b26bc-3bae-4155-a669-05a79451e62e)
