### PR TITLE
[WIP] Add WebRTC features to Linux

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,7 +56,7 @@ mundy = { version = "0.1.2", features = ["accent-color", "callback"] }
 tauri-plugin-notification = "2.0"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
-webkit2gtk = { version = "2.0", features = ["v2_4"] }
+webkit2gtk = "*"
 wgpu = { version = "23.0", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -28,6 +28,8 @@ use crate::{
   util::logger,
 };
 
+use webkit2gtk::{SettingsExt, WebViewExt};
+
 mod config;
 mod functionality;
 mod gpu;
@@ -48,6 +50,28 @@ fn git_hash() -> String {
 #[tauri::command]
 fn should_disable_plugins() -> bool {
   std::env::args().any(|arg| arg == "--disable-plugins")
+}
+
+fn enable_web_features(settings: &webkit2gtk::Settings) {
+  settings.set_enable_webrtc(true);
+  settings.set_enable_media(true);
+  settings.set_enable_mediasource(true);
+  settings.set_enable_media_capabilities(true);
+  settings.set_enable_encrypted_media(true);
+  settings.set_enable_media_stream(true);
+  settings.set_media_playback_requires_user_gesture(false);
+  settings.set_media_playback_allows_inline(true);
+  settings.set_media_content_types_requiring_hardware_support(None);
+}
+
+#[cfg(target_os = "linux")]
+fn allow_all_permissions(webview: &webkit2gtk::WebView) {
+  use webkit2gtk::{PermissionRequestExt, WebViewExt};
+  // Allow all permission requests for debugging
+  let _ = webview.connect_permission_request(move |_, request| {
+    request.allow();
+    true
+  });
 }
 
 fn main() {
@@ -269,7 +293,17 @@ fn main() {
       }
 
       let win = win.build()?;
-
+      app.webview_windows().values().for_each(|webview_window| {
+          if let Err(e) = webview_window.with_webview(|webview| {
+              if let Some(settings) = webview.inner().settings() {
+                  enable_web_features(&settings);
+                  #[cfg(target_os = "linux")]
+                  allow_all_permissions(&webview.inner());
+              }
+          }) {
+              eprintln!("Error configuring webview: {:?}", e);
+          }
+      });
       configure(&win);
       setup_autostart(app);
 


### PR DESCRIPTION
This PR is a starting point to enable media/WebRTC features to Linux currently it allows to get to this point : 
![image](https://github.com/user-attachments/assets/06e62982-35b2-4b54-9051-ba326490d557)

But the issue lies with the `navigator.getUserMedia()` this API is deprecated and not available in webkitGTK and now `navigator.mediaDevices.getUserMedia()` must be used, and using some polyfill or dirty JS injection doesn't solve the problem.
I'm putting this as a draft PR if one day either Discord or webkit changes something so it can be merged.
In the mean time if someone has an idea you are welcome to modify the code.