### PR TITLE
Add WinGet Package Repository auto-pull

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,22 @@
+name: Publish to WinGet Package Repository
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Extract version
+        id: extract-ver
+        run: |
+          $VER="${{ github.event.release.tag_name }}"
+          $SEMVER=$VER.Substring(1)
+          echo "SEMVER=$SEMVER" >> $env:GITHUB_OUTPUT
+
+      - uses: vedantmgoyal9/winget-releaser@3e78d7ff0f525445bca5d6a989d31cdca383372e
+        with:
+          identifier: SpikeHD.Dorion
+          version: ${{ steps.extract-ver.outputs.SEMVER }}
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This PR adds a new Publish to WinGet Package Repository workflow, which triggers on a proper release publish.

The workflow uses a pinned commit of `vedantmgoyal9/winget-releaser`, which utilizes `russellbanks/komac` internally.

A new environment secret, `WINGET_TOKEN` must be exposed to the workflow, which is a GitHub PAT token with the `public_repo` scope and _only that_.

The action itself creates a new PR on the WinGet Community Package Repository including all files that match this regex by default: `.(exe|msi|msix|appx)(bundle){0,1}$`