### PR TITLE
change spikehd.github.io to spikehd.dev in plugin references

### DIFF
--- a/src-tauri/injection/preinject.ts
+++ b/src-tauri/injection/preinject.ts
@@ -29,16 +29,16 @@ const INJECTED_PLUGIN_OPTIONS = {
 }
 
 window.SHELTER_INJECTOR_PLUGINS = {
-  'Dorion Titlebar': ['https://spikehd.github.io/shelter-plugins/dorion-titlebar/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Settings': ['https://spikehd.github.io/shelter-plugins/dorion-settings/', INJECTED_PLUGIN_OPTIONS],
-  'Always Trust': ['https://spikehd.github.io/shelter-plugins/always-trust/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Notifications': ['https://spikehd.github.io/shelter-plugins/dorion-notifications/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Streamer Mode': ['https://spikehd.github.io/shelter-plugins/dorion-streamer-mode/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Updater': ['https://spikehd.github.io/shelter-plugins/dorion-updater/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion PTT': ['https://spikehd.github.io/shelter-plugins/dorion-ptt/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Tray': ['https://spikehd.github.io/shelter-plugins/dorion-tray/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Fullscreen': ['https://spikehd.github.io/shelter-plugins/dorion-fullscreen/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Custom Keybinds': ['https://spikehd.github.io/shelter-plugins/dorion-custom-keybinds/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Titlebar': ['https://spikehd.dev/shelter-plugins/dorion-titlebar/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Settings': ['https://spikehd.dev/shelter-plugins/dorion-settings/', INJECTED_PLUGIN_OPTIONS],
+  'Always Trust': ['https://spikehd.dev/shelter-plugins/always-trust/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Notifications': ['https://spikehd.dev/shelter-plugins/dorion-notifications/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Streamer Mode': ['https://spikehd.dev/shelter-plugins/dorion-streamer-mode/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Updater': ['https://spikehd.dev/shelter-plugins/dorion-updater/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion PTT': ['https://spikehd.dev/shelter-plugins/dorion-ptt/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Tray': ['https://spikehd.dev/shelter-plugins/dorion-tray/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Fullscreen': ['https://spikehd.dev/shelter-plugins/dorion-fullscreen/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Custom Keybinds': ['https://spikehd.dev/shelter-plugins/dorion-custom-keybinds/', INJECTED_PLUGIN_OPTIONS],
 }
 
 ;(async () => {
@@ -281,3 +281,4 @@ async function displayLoadingTop() {
 
   document.body.appendChild(loadingContainer)
 }
+


### PR DESCRIPTION
the 301 responses that spikehd.github.io send to redirect you to spikehd.dev aren't handled by WebView. because of that, none of the plugins load, and I can't see any dorion configuration options. this literally just changes the static array that stores the urls to point to spikehd.dev instead of spikehd.github.io.