### PR TITLE
update extension urls to include 'www'

### DIFF
--- a/src-tauri/injection/preinject.ts
+++ b/src-tauri/injection/preinject.ts
@@ -29,16 +29,16 @@ const INJECTED_PLUGIN_OPTIONS = {
 }
 
 window.SHELTER_INJECTOR_PLUGINS = {
-  'Dorion Titlebar': ['https://spikehd.dev/shelter-plugins/dorion-titlebar/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Settings': ['https://spikehd.dev/shelter-plugins/dorion-settings/', INJECTED_PLUGIN_OPTIONS],
-  'Always Trust': ['https://spikehd.dev/shelter-plugins/always-trust/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Notifications': ['https://spikehd.dev/shelter-plugins/dorion-notifications/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Streamer Mode': ['https://spikehd.dev/shelter-plugins/dorion-streamer-mode/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Updater': ['https://spikehd.dev/shelter-plugins/dorion-updater/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion PTT': ['https://spikehd.dev/shelter-plugins/dorion-ptt/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Tray': ['https://spikehd.dev/shelter-plugins/dorion-tray/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Fullscreen': ['https://spikehd.dev/shelter-plugins/dorion-fullscreen/', INJECTED_PLUGIN_OPTIONS],
-  'Dorion Custom Keybinds': ['https://spikehd.dev/shelter-plugins/dorion-custom-keybinds/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Titlebar': ['https://www.spikehd.dev/shelter-plugins/dorion-titlebar/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Settings': ['https://www.spikehd.dev/shelter-plugins/dorion-settings/', INJECTED_PLUGIN_OPTIONS],
+  'Always Trust': ['https://www.spikehd.dev/shelter-plugins/always-trust/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Notifications': ['https://www.spikehd.dev/shelter-plugins/dorion-notifications/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Streamer Mode': ['https://www.spikehd.dev/shelter-plugins/dorion-streamer-mode/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Updater': ['https://www.spikehd.dev/shelter-plugins/dorion-updater/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion PTT': ['https://www.spikehd.dev/shelter-plugins/dorion-ptt/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Tray': ['https://www.spikehd.dev/shelter-plugins/dorion-tray/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Fullscreen': ['https://www.spikehd.dev/shelter-plugins/dorion-fullscreen/', INJECTED_PLUGIN_OPTIONS],
+  'Dorion Custom Keybinds': ['https://www.spikehd.dev/shelter-plugins/dorion-custom-keybinds/', INJECTED_PLUGIN_OPTIONS],
 }
 
 ;(async () => {
@@ -281,4 +281,5 @@ async function displayLoadingTop() {
 
   document.body.appendChild(loadingContainer)
 }
+
 


### PR DESCRIPTION
Unfortunately, I didn't test yesterday's pr, and as it turns out, setting the domains for plugins in `preinject.ts` to spikehd.dev wasn't enough - your web server sends `301`s to redirect to www.spikehd.dev. The sane way to fix this would most likely be to see if we can get Dorion to handle `301`s, but changing the url works. You can see below that on a browser, it only resolves on www.spikehd.dev.
<img width="1121" height="48" alt="Screenshot 2025-08-15 234800" src="https://github.com/user-attachments/assets/b04c88ed-fc94-4156-ba66-68f6f3b65c18" />

and once I built with the `www` subdomain in the list, the section finally appeared.
<img width="240" height="294" alt="image" src="https://github.com/user-attachments/assets/f7fc5cd7-9f8a-4264-91e7-e35cdca01706" />
