### PR TITLE
Update README.md to remove quarantine attribute from Dorion

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,12 @@ If you submit an issue or ask a question in the Discord, it's likely you will be
   WEBKIT_DISABLE_COMPOSITING_MODE=1
   WEBKIT_DISABLE_DMABUF_RENDERER=1
   ```
+## MacOS
+### ""Dorion.app" is damaged and can't be opened"
+* To solve this issue run this command and then enter your password:
+  ```sh
+  sudo xattr -r -d com.apple.quarantine /Applications/Dorion.app
+  ```
 
 # TODO
 
@@ -430,3 +436,4 @@ Theme: [Catpuccin - Frappe](https://github.com/catppuccin/discord)
 <img width="100%" src="https://github.com/SpikeHD/Dorion/assets/25207995/c73a2333-31fb-404a-9489-5e1b1f8cfa54" />
 
 Theme: [Fluent](https://betterdiscord.app/theme/Fluent)
+


### PR DESCRIPTION
When I installed Dorion through HomeBrew and tried to open I got the "Dorion.app is damaged" error, which is not really true, it's just that apple tries to block unverified apps. 
To solve that issue all you have to do is to disable the quarantine attribute with :
sudo xattr -r -d com.apple.quarantine /Applications/Dorion.app 