### PR TITLE
fix: reduce querySelector loops

### DIFF
--- a/src-tauri/injection/postinject.ts
+++ b/src-tauri/injection/postinject.ts
@@ -1,5 +1,5 @@
 import { applyExtraCSS } from './shared/ui'
-import { waitForDom, waitForElmEx } from './shared/util';
+import { waitForElmEx } from './shared/wait_elm';
 import { initWindowsKeybinds } from './shared/windows_keybinds'
 
 (async () => {

--- a/src-tauri/injection/preinject.ts
+++ b/src-tauri/injection/preinject.ts
@@ -1,6 +1,7 @@
 import { badPostMessagePatch, createLocalStorage, proxyFetch, proxyXHR, proxyAddEventListener, proxyOpen, proxyNotification } from './shared/recreate'
 import { extraCssChangeWatch, safemodeTimer, typingAnim } from './shared/ui'
-import { cssSanitize, fetchImage, isJson, waitForApp, waitForElm, waitForElmEx, saferEval, timeout } from './shared/util'
+import { cssSanitize, fetchImage, isJson, waitForApp, waitForElm, saferEval, timeout } from './shared/util'
+import { waitForElmEx } from './shared/wait_elm'
 
 // Let's expose some stuff for use in plugins and such
 window.Dorion = {

--- a/src-tauri/injection/shared/util.ts
+++ b/src-tauri/injection/shared/util.ts
@@ -1,3 +1,5 @@
+import { waitForElmEx } from "./wait_elm"
+
 export function cssSanitize(css: string) {
   const style = document.createElement('style')
   style.innerHTML = css
@@ -23,107 +25,6 @@ export function isJson(s: string) {
     return false
   }
   return true
-}
-
-/**
- * Observes the DOM for newly added nodes and executes a callback for each.
- * @template T - The type of the value that the Promise will eventually resolve to.
- * @param {Node} rootElm - The DOM node to start observing from (e.g., document.body).
- * @param {(Node, resolve(T)) => boolean} callbackFn - A function executed for every added node.
- * - Call `resolve(value)` to fulfill the promise.
- * - Return `false` to disconnect the observer and stop listening.
- * - Return `true` to continue observing for more nodes.
- * * @returns {Promise<T>} A promise that resolves when `resolve()` is called within the callback.
- * * @example
- * const target = await observeDom<HTMLDivElement>(document.body, (node, resolve) => {
- *   if (node instanceof HTMLDivElement && node.id === 'my-element') {
- *     resolve(node);
- *     return false; // Found it, stop observing
- *   }
- *   return true; // Keep looking
- * });
- */
-function observeDom<T>(rootElm: Node, callbackFn: (node: Node, resolve: (value: T) => void) => boolean, subtree: boolean): Promise<T> {
-  return new Promise((resolve) => {
-    const observer = new MutationObserver(mutations => {
-      for (const mutation of mutations) {
-        if (mutation.type === 'childList') {
-          const addedNodes = Array.from(mutation.addedNodes)
-          for (const node of addedNodes) {
-            if (!callbackFn(node, resolve)) {
-              observer.disconnect()
-              return
-            }
-          }
-        }
-      }
-    })
-    observer.observe(rootElm, {
-      childList: true,
-      subtree // reduce callback count for perf
-    })
-  })
-}
-
-// Ensure at least one element on the chain would callback
-type query = Array<string> | string
-type waitCfg = { callbackFn: null | ((elm: Element) => void), root: Element, timeout: number }
-const isString = (v: any) => typeof v === 'string' || v instanceof String
-const subtreeFind = (p: Element, q: Array<string>) => Array.from(p.children).find(c => q.some(q => c.matches(q)))
-const queryFind = (p: Element, query: Array<string>) => {
-  for (let q of query) {
-    const subtree = q[0] === '>'
-    if (subtree) q = q.slice(1)
-    const elm = subtree ? subtreeFind(p, [q]) : p.querySelector(q)
-    if (elm) return elm
-  }
-  return
-}
-export async function waitForElmEx(queries: Array<query> | query, cfg: Partial<waitCfg> = {}): Promise<Element> {
-  const callbackFn = cfg.callbackFn;
-  let root = typeof cfg.root !== 'undefined' ? cfg.root : document.body;
-  const timeout = cfg.timeout;
-
-  let query: string[]
-  let stop = false;
-  if (timeout) setTimeout(() => { stop = true }, timeout)
-
-  if (isString(queries)) queries = [queries]
-  loop: while (queries.length) {
-    // prepare query
-    const q = queries.shift()
-    if (!q) break
-    query = isString(q) ? [q] : q
-    const subtree = query.every(q => q[0] === '>')
-    if (subtree) query = query.map(q => q.slice(1))
-    // no observe if this elm already exist
-    const elm = subtree ? subtreeFind(root, query) : queryFind(root, query)
-    if (elm) { root = elm; if (callbackFn) callbackFn(root); continue loop }
-    // start observer
-    root = await observeDom(root, (node, res) => {
-      if (stop) { res(root); return false }
-      if (node.nodeType !== Node.ELEMENT_NODE) return true
-      const e = node as Element
-      for (let q of query) {
-        if (!subtree) {
-          const s = q[0] === '>'
-          if (s) q = q.slice(1)
-        }
-        let ret = e.matches(q) ? e : null
-        if (!ret) {
-          ret = e.querySelector(q)
-        }
-        if (ret) {
-          res(e)
-          return false
-        }
-      }
-      return true
-    }, subtree) as Element
-    // callback after found
-    if (callbackFn) callbackFn(root)
-  }
-  return root
 }
 
 /**

--- a/src-tauri/injection/shared/wait_elm.ts
+++ b/src-tauri/injection/shared/wait_elm.ts
@@ -1,0 +1,83 @@
+// Observes the DOM for newly added nodes and executes a callback for each.
+function observeDom<T>(rootElm: Node, callbackFn: (node: Node, resolve: (value: T) => void) => boolean, subtree: boolean): Promise<T> {
+  return new Promise((resolve) => {
+    const observer = new MutationObserver(mutations => {
+      for (const mutation of mutations) {
+        if (mutation.type === 'childList') {
+          const addedNodes = Array.from(mutation.addedNodes)
+          for (const node of addedNodes) {
+            if (!callbackFn(node, resolve)) {
+              observer.disconnect()
+              return
+            }
+          }
+        }
+      }
+    })
+    observer.observe(rootElm, {
+      childList: true,
+      subtree
+    })
+  })
+}
+
+// Ensure at least one element on the chain would callback
+type query = Array<string> | string
+type waitCfg = { callbackFn: null | ((elm: Element) => void), root: Element, timeout: number }
+const isString = (v: any) => typeof v === 'string' || v instanceof String
+const subtreeFind = (p: Element, q: Array<string>) => Array.from(p.children).find(c => q.some(q => c.matches(q)))
+const queryFind = (p: Element, query: Array<string>) => {
+  for (let q of query) {
+    const subtree = q[0] === '>'
+    if (subtree) q = q.slice(1)
+    const elm = subtree ? subtreeFind(p, [q]) : p.querySelector(q)
+    if (elm) return elm
+  }
+  return
+}
+export async function waitForElmEx(queries: Array<query> | query, cfg: Partial<waitCfg> = {}): Promise<Element> {
+  const callbackFn = cfg.callbackFn;
+  let root = typeof cfg.root !== 'undefined' ? cfg.root : document.body;
+  const timeout = cfg.timeout;
+
+  let query: string[]
+  let stop = false;
+  if (timeout) setTimeout(() => { stop = true }, timeout)
+
+  if (isString(queries)) queries = [queries]
+  loop: while (queries.length) {
+    // prepare query
+    const q = queries.shift()
+    if (!q) break
+    query = isString(q) ? [q] : q
+    const subtree = query.every(q => q[0] === '>')
+    if (subtree) query = query.map(q => q.slice(1))
+    // no observe if this elm already exist
+    const elm = subtree ? subtreeFind(root, query) : queryFind(root, query)
+    if (elm) { root = elm; if (callbackFn) callbackFn(root); continue loop }
+    // start observer
+    root = await observeDom(root, (node, res) => {
+      if (stop) { res(root); return false }
+      if (node.nodeType !== Node.ELEMENT_NODE) return true
+      const e = node as Element
+      for (let q of query) {
+        if (!subtree) {
+          const s = q[0] === '>'
+          if (s) q = q.slice(1)
+        }
+        let ret = e.matches(q) ? e : null
+        if (!ret) {
+          ret = e.querySelector(q)
+        }
+        if (ret) {
+          res(e)
+          return false
+        }
+      }
+      return true
+    }, subtree) as Element
+    // callback after found
+    if (callbackFn) callbackFn(root)
+  }
+  return root
+}


### PR DESCRIPTION
introduced the over-complicated `waitForElmEx` function from SpikeHD/shelter-plugins#60

hope to just use it in `dorion-titlebar`