### PR TITLE
fix: self-sign app bundle on macOS to avoid damaged warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@
 > You can find portable builds in the [releases](https://github.com/SpikeHD/dorion/releases/latest/) page. You can also [build](#building) Dorion yourself!
 
 > [!NOTE]
-> ***MacOS Users***: If opening Dorion gives you "Dorion.app is damaged and cannot be opened", MacOS is lying to you and you may just need to run `sudo xattr -rd com.apple.quarantine /Applications/Dorion.app`. Alternatively, you can open the **Privacy & Security** settings pane and scroll down to the **Security** section to remove the quarantine.
+> ***MacOS Users***: If opening Dorion gives you "Dorion.app cannot be opened because it is from an unidentified developer", you may just need to run `sudo xattr -rd com.apple.quarantine /Applications/Dorion.app`. Alternatively, you can open the **Privacy & Security** settings pane and scroll down to the **Security** section to remove the quarantine.
 >
 > ***Windows Users***: Defender may think Dorion is a virus. This just happens sometimes, and if SmartScreen blocks it from running, click "More Info" and "Run Anyways". Feel free to scan Dorion with [Virustotal](https://www.virustotal.com/gui/home/upload)!
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       "exceptionDomain": "",
       "frameworks": [],
       "providerShortName": null,
-      "signingIdentity": null
+      "signingIdentity": "-"
     },
     "resources": [
       "injection/shelter.js",


### PR DESCRIPTION
https://v2.tauri.app/distribute/sign/macos/#ad-hoc-signing

https://github.com/nekename/OpenDeck/commit/e16c8920c0415d1035249037b84e314c72cef679

https://discord.com/channels/616186924390023171/1327010170659934229/1327010704682778654 (Tauri server)

Figured the unidentified developer warning is better than the damaged warning, since users normally know what to do with that.

Haven't actually tested this with Dorion but it works in my project