### PR TITLE
[WIP] somewhat match macos official client's titlebar setup

### DIFF
--- a/src-tauri/injection/postinject.ts
+++ b/src-tauri/injection/postinject.ts
@@ -11,6 +11,34 @@ import { initWindowsKeybinds } from './shared/windows_keybinds'
   initWindowsKeybinds()
   // Load up our extra css
   applyExtraCSS()
+  if (document.documentElement.dataset.dorionPlatform === "macos") {
+    const setupDragRegion = () => {
+      // Find title_ element at top of window (the actual titlebar, not username panel)
+      const titleElements = document.querySelectorAll('[class*="title_"]');
+      for (const el of Array.from(titleElements)) {
+        const rect = el.getBoundingClientRect();
+        if (rect.top < 10 && rect.height > 20 && rect.height < 50) {
+          // Found the titlebar - set drag attribute on it and all non-interactive children
+          el.setAttribute("data-tauri-drag-region", "");
+          el.querySelectorAll("*").forEach((child) => {
+            if (
+              !child.matches('button, a, input, [role="button"], svg, path')
+            ) {
+              child.setAttribute("data-tauri-drag-region", "");
+            }
+          });
+          return true;
+        }
+      }
+      return false;
+    };
+
+    // Retry until Discord UI loads
+    const interval = setInterval(() => {
+      if (setupDragRegion()) clearInterval(interval);
+    }, 100);
+  };
+
 
   // The comment ahead is read by tauri and used to insert theme injection code
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -308,6 +308,11 @@ fn main() {
         )
         .zoom_hotkeys_enabled(true)
         .browser_extensions_enabled(true);
+        #[cfg(target_os = "macos")]
+        {
+          win = win.title_bar_style(tauri::TitleBarStyle::Overlay);
+          win = win.hidden_title(true);
+        }
 
       if !args::is_safemode() {
         // Preinject is bundled with "use strict" so we put it in it's own function to prevent potential client mod issues

--- a/src/extra.css
+++ b/src/extra.css
@@ -18,3 +18,7 @@ html:not([data-dorion-platform='macos']) div[class^='base'] div[class^='bar_'] {
   z-index: 9999;
   background-color: var(--background-base-lowest);
 }
+
+html[data-dorion-platform="macos"] {
+  padding-top: 2px;
+}


### PR DESCRIPTION
Official Discord client in macos
<img width="1758" height="144" alt="ss0124@004300@2x" src="https://github.com/user-attachments/assets/0c93cec2-a301-4518-abcd-0fe3f49bc04d" />
Dorion with traffic light overlay
<img width="1804" height="166" alt="ss0124@004312@2x" src="https://github.com/user-attachments/assets/e4f9bb65-2c97-4265-8fe0-a88a0b160d01" />

## pending issues

### 1. cannot drag by clicking on title bar
This should be solvable easily. I was trying to add something like
```css
html[data-dorion-platform="macos"] div[class*="bar_"] {
    -webkit-app-region: drag;
}
```
in src/extra.css
but webkit-app-region doesn't seem to take effect.
any pointers on what might be the issue would be nice.
my current workaround is cmd+crtl click n drag

### 2. traffic light size
the custom traffic lights used in official client are smaller
<img width="400" alt="ss0124@003929@2x" src="https://github.com/user-attachments/assets/5079ea2e-a66e-4730-84f3-a67876b30c85" />
it requires writing a custom title-bar and i don't think this is a blocker