### PR TITLE
Add one-run safe mode recovery shortcut

### DIFF
--- a/src-tauri/injection/shared/ui.ts
+++ b/src-tauri/injection/shared/ui.ts
@@ -21,6 +21,11 @@ export function safemodeTimer(elm: HTMLDivElement) {
     if (evt.code === 'KeyF') {
       window.__TAURI__.core.invoke('open_themes')
     }
+
+    // If S, relaunch once in safe mode.
+    if (evt.code === 'KeyS') {
+      window.__TAURI__.core.invoke('restart_in_safemode')
+    }
   }
 
   document.addEventListener('keydown', tmpKeydown)

--- a/src-tauri/src/args.rs
+++ b/src-tauri/src/args.rs
@@ -28,7 +28,10 @@ pub struct Args {
   #[options(help = "(windows only) additional arguments to pass to the webview process")]
   pub webview_args: String,
 
-  #[options(help = "set the profile to load. overrides the profile set in config", meta = "PROFILE")]
+  #[options(
+    help = "set the profile to load. overrides the profile set in config",
+    meta = "PROFILE"
+  )]
   pub profile: Option<String>,
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -242,6 +242,7 @@ fn main() {
       config::read_config_file,
       config::write_config_file,
       config::default_config,
+      helpers::restart_in_safemode,
       theme::get_themes,
       theme::get_theme_names,
       theme::get_enabled_themes,

--- a/src-tauri/src/util/helpers.rs
+++ b/src-tauri/src/util/helpers.rs
@@ -1,6 +1,8 @@
 use super::paths::*;
 use base64::{engine::general_purpose, Engine as _};
-use std::path::*;
+use std::{path::*, process::Command};
+
+use crate::log;
 
 #[tauri::command]
 pub async fn fetch_image(url: String) -> Option<String> {
@@ -70,6 +72,22 @@ pub fn get_platform() -> &'static str {
 
   #[cfg(target_os = "linux")]
   "linux"
+}
+
+#[tauri::command]
+pub fn restart_in_safemode(app: tauri::AppHandle) {
+  let current_exe = match std::env::current_exe() {
+    Ok(current_exe) => current_exe,
+    Err(e) => {
+      log!("Failed to resolve current executable for safemode restart: {e:?}");
+      return;
+    }
+  };
+
+  match Command::new(current_exe).arg("--safemode").spawn() {
+    Ok(_) => app.exit(0),
+    Err(e) => log!("Failed to restart Dorion in safemode: {e:?}"),
+  }
 }
 
 #[cfg(target_os = "windows")]

--- a/src/index.html
+++ b/src/index.html
@@ -22,6 +22,9 @@
       You can also press "F" to open your themes/plugins folder, in case any of
       those broke something.
     </p>
+    <p>
+      Press "S" to restart Dorion in safe mode if startup keeps failing.
+    </p>
   </div>
 </div>
 <!-- I'm just gonna be super lazy and put this here since I can get away with it -->


### PR DESCRIPTION
## Summary
- add a loading-screen recovery shortcut: press S to relaunch Dorion once with --safemode
- reuse Dorion's existing safemode path without adding a persistent config option
- keep the macOS User-Agent change out of this PR; it is now split into #463

## Why
When startup injection or client-side additions prevent Discord from rendering, users can currently recover only by manually launching Dorion with --safemode. That is hard to discover from a blank or stuck loading screen.

This keeps normal startup as the default and makes safe mode a one-run recovery action. Pressing S starts a new Dorion process with --safemode and exits the current process, so the next regular launch is not stuck in safe mode.

## Validation
- cargo fmt --manifest-path ./src-tauri/Cargo.toml --all -- --check
- pnpm exec eslint src-tauri/injection/shared/ui.ts
- pnpm build:js
- cargo check --manifest-path ./src-tauri/Cargo.toml

## Notes
- Full pnpm lint still reports pre-existing issues in src-tauri/injection/shared/recreate.ts and src-tauri/injection/shared/wait_elm.ts.
- cargo check passes with existing warnings in unrelated notification/keyboard code.
