### PR TITLE
feat: add min_inner_size to the main window

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -304,6 +304,7 @@ fn main() {
       let mut win = WebviewWindowBuilder::new(app, "main", url_ext)
         .title(title.as_str())
         .resizable(true)
+        .min_inner_size(800.0, 600.0)
         .disable_drag_drop_handler()
         .data_directory(get_webdata_dir())
         // Prevent flickering by starting hidden, and show later


### PR DESCRIPTION
## Hello!
This pull request adds the minimum size for the main window to prevent it from looking ugly. (#467) 
I tested it on MacOS (not on other operating systems), but it works anywhere else because it uses the Tauri API, which is already tested on every OS. 

## Preview
**BEFORE**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/81c44839-6095-40bf-9579-4a348a320322" />
**AFTER**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2b592269-b7ce-467b-bf88-71734ca4e7a1" />
