### PR TITLE
fix: set WebRTC IP handling policy for WebView2

### DIFF
--- a/src-tauri/extension/background.js
+++ b/src-tauri/extension/background.js
@@ -1,0 +1,26 @@
+// Avoid Discord voice/video getting stuck at "DTLS Connecting" under
+// VPN/TUN/fake-IP setups where WebRTC may pick a non-default interface.
+const POLICY = "default_public_and_private_interfaces";
+
+function applyWebRtcPolicy() {
+  const setting = chrome?.privacy?.network?.webRTCIPHandlingPolicy;
+
+  if (!setting) {
+    console.warn("[Dorion WebRTC] chrome.privacy.network.webRTCIPHandlingPolicy is unavailable");
+    return;
+  }
+
+  setting.set({ value: POLICY }, () => {
+    if (chrome.runtime.lastError) {
+      console.warn("[Dorion WebRTC] Failed to set WebRTC policy:", chrome.runtime.lastError.message);
+      return;
+    }
+
+    console.log("[Dorion WebRTC] Applied WebRTC IP handling policy:", POLICY);
+  });
+}
+
+chrome.runtime.onInstalled.addListener(applyWebRtcPolicy);
+chrome.runtime.onStartup.addListener(applyWebRtcPolicy);
+
+applyWebRtcPolicy();

--- a/src-tauri/extension/manifest.json
+++ b/src-tauri/extension/manifest.json
@@ -1,16 +1,27 @@
 {
   "name": "Dorion Header Destroyer",
-  "version": "1.0",
+  "version": "1.1",
   "homepage_url": "https://github.com/SpikeHD/Dorion",
-  "description": "Destroy CSP in Discord request headers",
+  "description": "Destroy CSP in Discord request headers and configure WebRTC IP handling",
   "manifest_version": 3,
-  "permissions": ["declarativeNetRequest"],
-  "host_permissions": ["*://*.discord.com/*", "*://discord.com/*"],
+  "permissions": [
+    "declarativeNetRequest",
+    "privacy"
+  ],
+  "host_permissions": [
+    "*://*.discord.com/*",
+    "*://discord.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "declarative_net_request": {
-    "rule_resources": [{
-      "id": "csp_disabler",
-      "path": "dnr-rules.json",
-      "enabled": true
-    }]
+    "rule_resources": [
+      {
+        "id": "csp_disabler",
+        "path": "dnr-rules.json",
+        "enabled": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
Idea taken from: [PR for a similar issue in Vesktop](https://github.com/Vencord/Vesktop/pull/1251)

Discord voice gets stuck at DTLS Connecting in Dorion when using proxy setups that include virtual network adapters. WebView2 still opens UDP sockets on physical LAN.
Setting WebRTC IP handling policy through the bundled extension fixes the issue.