### PR TITLE
fix: don't flash taskbar icon on everything

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -264,6 +264,10 @@ fn main() {
       util::color::get_os_accent,
     ])
     .on_window_event(|window, event| match event {
+      tauri::WindowEvent::Focused(true) => {
+        // Stop flashing the taskbar icon
+        let _ = window.request_user_attention(None);
+      }
       tauri::WindowEvent::Resized { .. } => {
         // Sleep for a millisecond (blocks the thread but it doesn't really matter)
         // https://github.com/tauri-apps/tauri/issues/6322#issuecomment-1448141495

--- a/src-tauri/src/util/notifications.rs
+++ b/src-tauri/src/util/notifications.rs
@@ -25,6 +25,11 @@ pub fn send_notification(
   icon: String,
   additional_data: Option<AdditionalData>,
 ) {
+  // Flash the taskbar icon
+  if !win.is_focused().unwrap_or(false) {
+    let _ = win.request_user_attention(Some(tauri::UserAttentionType::Informational));
+  }
+
   // Write the result of the icon
   let app = win.app_handle();
   let client = reqwest::blocking::Client::new();
@@ -200,13 +205,6 @@ pub fn notification_count(window: tauri::WebviewWindow, amount: i64) {
   log!("Setting notification count: {}", amount);
 
   notification_count_inner(&window, amount);
-
-  if amount > 0 && !window.is_focused().unwrap() {
-    use tauri::UserAttentionType;
-    let _ = window.request_user_attention(Some(UserAttentionType::Informational));
-  } else {
-    let _ = window.request_user_attention(None);
-  }
 
   // If the tray state is unread or default,
   if TrayIcon::from_usize(TRAY_STATE.load(Ordering::Relaxed)).is_overwrite() {


### PR DESCRIPTION
Only flash taskbar icon when Dorion sends a desktop notification.
I think this will match normal Discord behavior now...
Requires desktop notifications to be enabled in settings

Tested on Windows

btw when i was testing, toggling "Enable Desktop Notifications" didn't change the value of desktop_notifications in config.json, might be something worth looking into?

Fixes #460 #482 