### PR TITLE
fix: resolve clippy -D warnings blocking Windows CI build

### DIFF
--- a/src-tauri/src/args.rs
+++ b/src-tauri/src/args.rs
@@ -42,7 +42,7 @@ impl Args {
 }
 
 // Lazy static to hold parsed args
-static PARSED_ARGS: LazyLock<Args> = LazyLock::new(|| Args::parse());
+static PARSED_ARGS: LazyLock<Args> = LazyLock::new(Args::parse);
 
 pub fn is_help() -> bool {
   // Parsing will automatically print help information

--- a/src-tauri/src/functionality/configure/mod.rs
+++ b/src-tauri/src/functionality/configure/mod.rs
@@ -31,6 +31,9 @@ use super::rpc::start_rpc_server;
 use super::tray::create_tray;
 
 pub fn configure(window: &tauri::WebviewWindow) {
+  // `config` is only read behind certain `#[cfg(feature = ...)]` blocks below,
+  // so it can appear unused depending on which features are enabled for this build.
+  #[allow(unused_variables)]
   let config = get_config();
   let handle = window.app_handle();
 

--- a/src-tauri/src/functionality/keyboard.rs
+++ b/src-tauri/src/functionality/keyboard.rs
@@ -6,6 +6,9 @@ use livesplit_hotkey::Hotkey;
 use livesplit_hotkey::KeyCode;
 use serde::{Deserialize, Serialize};
 
+// Only ever produced via `serde_json::from_str` (see functionality::hotkeys),
+// never constructed as a struct literal, which trips the dead_code lint.
+#[allow(dead_code)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct KeybindChangedEvent {
   pub keys: Vec<KeyStruct>,

--- a/src-tauri/src/util/notifications.rs
+++ b/src-tauri/src/util/notifications.rs
@@ -154,7 +154,7 @@ fn send_notification_internal_windows(
     .text2(body.as_str())
     .sound(None);
 
-  if let Some(data) = &additional_data {
+  if let Some(_data) = &additional_data {
     toast = toast.on_activated({
       let additional_data = additional_data.clone();
 


### PR DESCRIPTION
- args.rs: replace redundant closure with Args::parse function reference
- functionality/configure/mod.rs: allow(unused_variables) on config, only read behind certain cfg(feature) blocks
- functionality/keyboard.rs: allow(dead_code) on KeybindChangedEvent, only ever constructed via serde_json::from_str, not as a literal
- util/notifications.rs: rename unused data binding to _data in send_notification_internal_windows