### PR TITLE
Set reqwest connect_timeout so multi-IP fallback engages

### DIFF
--- a/src-tauri/src/functionality/rpc.rs
+++ b/src-tauri/src/functionality/rpc.rs
@@ -10,7 +10,7 @@ use sysinfo::{ProcessRefreshKind, RefreshKind, System};
 use tauri::{Emitter, Listener};
 use window_titles::ConnectionTrait;
 
-use crate::{config::get_config, log, util::paths::custom_detectables_path};
+use crate::{config::get_config, log, util::http::blocking_client, util::paths::custom_detectables_path};
 
 // We keep track of this A) To not spam enable and B) to allow for the user to manually disable without it being re-enabled automatically
 static OBS_OPEN: AtomicBool = AtomicBool::new(false);
@@ -66,7 +66,7 @@ pub fn start_rpc_server(win: tauri::WebviewWindow) {
   };
 
   let detectable =
-    match reqwest::blocking::get("https://discord.com/api/v9/applications/detectable") {
+    match blocking_client().get("https://discord.com/api/v9/applications/detectable").send() {
       Ok(resp) => match resp.text() {
         Ok(text) => text,
         Err(e) => {

--- a/src-tauri/src/injection/client_mod.rs
+++ b/src-tauri/src/injection/client_mod.rs
@@ -4,6 +4,7 @@ use phf::phf_map;
 use crate::{
   config::{get_config, write_config_file},
   log,
+  util::http::blocking_client,
 };
 
 flate!(pub static FALLBACK: str from "./injection/shelter.js");
@@ -64,7 +65,7 @@ pub fn load_mods_js() -> String {
       .script;
 
     tasks.push(std::thread::spawn(move || {
-      let response = match reqwest::blocking::get(script_url) {
+      let response = match blocking_client().get(script_url).send() {
         Ok(r) => r,
         Err(e) => {
           log!("Failed to load client mod JS for {}: {:?}", mod_name, e);
@@ -145,7 +146,7 @@ pub fn load_mods_css() -> String {
     }
 
     tasks.push(std::thread::spawn(move || {
-      let response = match reqwest::blocking::get(styles_url) {
+      let response = match blocking_client().get(styles_url).send() {
         Ok(r) => r,
         Err(e) => {
           log!("Failed to load client mod CSS for {}: {:?}", mod_name, e);

--- a/src-tauri/src/injection/theme.rs
+++ b/src-tauri/src/injection/theme.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use crate::{config::get_config, util::paths::get_theme_dir};
+use crate::{config::get_config, util::http::blocking_client, util::paths::get_theme_dir};
 
 fn theme_is_enabled(name: String) -> bool {
   let config = get_config();
@@ -82,7 +82,7 @@ pub fn theme_from_link(link: String, filename: Option<String>) -> String {
     filename.push_str(".css");
   }
 
-  let resp = reqwest::blocking::get(&link);
+  let resp = blocking_client().get(&link).send();
 
   if resp.is_err() {
     return String::new();

--- a/src-tauri/src/processors/css_preprocess.rs
+++ b/src-tauri/src/processors/css_preprocess.rs
@@ -2,6 +2,7 @@ use regex::Regex;
 use std::fs;
 
 use crate::log;
+use crate::util::http::blocking_client;
 use crate::util::paths::get_theme_dir;
 
 #[tauri::command]
@@ -70,7 +71,7 @@ pub fn localize_imports(win: tauri::WebviewWindow, css: String, name: String) ->
     tasks.push(std::thread::spawn(move || {
       log!("Getting: {}", &url);
 
-      let response = match reqwest::blocking::get(format!("https://{}", url)) {
+      let response = match blocking_client().get(format!("https://{}", url)).send() {
         Ok(r) => r,
         Err(e) => {
           log!("Request failed: {}", e);
@@ -273,7 +274,7 @@ pub fn localize_images(win: tauri::WebviewWindow, css: String) -> String {
     tasks.push(std::thread::spawn(move || {
       log!("Getting: {}", &url);
 
-      let response = match reqwest::blocking::get(url) {
+      let response = match blocking_client().get(url).send() {
         Ok(r) => r,
         Err(e) => {
           log!("Request failed: {}", e);

--- a/src-tauri/src/processors/js_preprocess.rs
+++ b/src-tauri/src/processors/js_preprocess.rs
@@ -1,11 +1,12 @@
 use crate::log;
+use crate::util::http::async_client;
 
 pub async fn localize_js(url: String) -> String {
   if url.is_empty() {
     return String::new();
   }
 
-  let response = match reqwest::get(&url).await {
+  let response = match async_client().get(&url).send().await {
     Ok(r) => r,
     Err(e) => {
       log!("Request failed: {}", e);

--- a/src-tauri/src/release.rs
+++ b/src-tauri/src/release.rs
@@ -1,6 +1,7 @@
 use tauri::{Emitter, Manager};
 
 use crate::log;
+use crate::util::http::async_client;
 use crate::util::paths::{config_is_local, updater_dir};
 
 #[tauri::command]
@@ -68,7 +69,7 @@ pub async fn maybe_latest_main_release(
   win: &tauri::WebviewWindow,
 ) -> Result<bool, Box<dyn std::error::Error + Sync + Send>> {
   let url = "https://api.github.com/repos/SpikeHD/Dorion/releases/latest";
-  let client = reqwest::Client::new();
+  let client = async_client();
   let response = client
     .get(url)
     .header("User-Agent", "Dorion")

--- a/src-tauri/src/util/helpers.rs
+++ b/src-tauri/src/util/helpers.rs
@@ -3,10 +3,11 @@ use base64::{Engine as _, engine::general_purpose};
 use std::{path::*, process::Command};
 
 use crate::log;
+use crate::util::http::async_client;
 
 #[tauri::command]
 pub async fn fetch_image(url: String) -> Option<String> {
-  let client = reqwest::Client::new();
+  let client = async_client();
   let response = client
     .get(url)
     .header("User-Agent", "Dorion")

--- a/src-tauri/src/util/http.rs
+++ b/src-tauri/src/util/http.rs
@@ -1,0 +1,19 @@
+use std::time::Duration;
+
+// Per-IP connect timeout so reqwest's multi-IP fallback (hyper) engages
+// instead of stalling on one dead anycast address. See reqwest#1939, reqwest#1940.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub fn blocking_client() -> reqwest::blocking::Client {
+  reqwest::blocking::Client::builder()
+    .connect_timeout(CONNECT_TIMEOUT)
+    .build()
+    .expect("failed to build reqwest blocking client")
+}
+
+pub fn async_client() -> reqwest::Client {
+  reqwest::Client::builder()
+    .connect_timeout(CONNECT_TIMEOUT)
+    .build()
+    .expect("failed to build reqwest client")
+}

--- a/src-tauri/src/util/mod.rs
+++ b/src-tauri/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod color;
 pub mod helpers;
+pub mod http;
 pub mod logger;
 pub mod notifications;
 pub mod paths;

--- a/src-tauri/src/util/notifications.rs
+++ b/src-tauri/src/util/notifications.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::Ordering;
 use crate::{
   functionality::tray::{TRAY_STATE, TrayIcon, set_tray_icon},
   log,
+  util::http::blocking_client,
   util::window_helpers::ultrashow,
 };
 use tauri::Manager;
@@ -38,7 +39,7 @@ pub fn send_notification(
     return;
   }
 
-  let client = reqwest::blocking::Client::new();
+  let client = blocking_client();
   let mut res = match client.get(icon).send() {
     Ok(res) => res,
     Err(e) => {


### PR DESCRIPTION
This resolves #493.

Bare `reqwest::blocking::get()` and `Client::new()` default to `connect_timeout: None`, which leaves `hyper`'s per-IP fallback (reqwest#1940) dormant. When a host resolves to multiple anycast IPs and the first one is unreachable, the request stalls until the OS TCP timeout instead of trying the next address.

Add shared `blocking_client()`/`async_client()` helpers with a 10s `connect_timeout` and route all eight request sites through them.

💘 Generated with Crush
Assisted-by: Crush:z-ai/glm-5.2

The final result:
<details><summary>Logs</summary>

```
[2026-08-15 03:12:43] Are we portable? false
[2026-08-15 03:12:43] Starting Dorion version v6.13.0
[2026-08-15 03:12:43] Opening Discord default
[2026-08-15 03:12:43] Joining (load_mods_js)...
[2026-08-15 03:12:46] Joining (load_mods_js)...
[2026-08-15 03:12:46] Plugins updated
[2026-08-15 03:12:46] Extensions are unsupported on non-Windows platforms!
[2026-08-15 03:12:46] Loading plugins...
[2026-08-15 03:12:46] Preload only: true
[2026-08-15 03:12:46] Starting OS accent subscriber...
[2026-08-15 03:12:46] Accent color changed Some(Srgba { _: #f74f9eff, red: 0.9686274509803922, green: 0.30980392156862746, blue: 0.6196078431372549, alpha: 1.0 })
[2026-08-15 03:12:46] Autolaunch enabled: false
[2026-08-15 03:12:46] Loading plugins...
[2026-08-15 03:12:46] Preload only: false
[2026-08-15 03:12:49] Joining (load_mods_css)...
[2026-08-15 03:12:54] Setting notification count: 0
[2026-08-15 03:12:54] Setting tray icon to default
[2026-08-15 03:12:54] Checking for updates...
[2026-08-15 03:12:54] Checking for updates...
[2026-08-15 03:12:56] Setting notification count: 90
[2026-08-15 03:12:56] Setting tray icon to unread
[2026-08-15 03:12:56] Setting notification count: 90
[2026-08-15 03:12:56] Setting tray icon to unread
```

</details>

It works. I tested 2-3 times by building `main` then building this commit, it consistently worked with the commit, and failed with `main`. 

Also, load times seem to be faster. Maybe it's because the timeout is causing degraded routes to fail early and move on to the next address (if not it would have waited 15-20 seconds for the response, which definitely is slow for startup).

Another intermittent issue that I keep having is dorion loading discord, but no shelter settings/dorion settings were available. This was probably because of `shelter.js` timing out - this PR should help in some cases like those too.